### PR TITLE
Add new feed type - hDAO thresholded

### DIFF
--- a/config.js
+++ b/config.js
@@ -9,7 +9,10 @@ const mainnet = {
     nftSwapMap: 523,
     curationsPtr: 519,
     nftRoyaltiesMap: 522,
-    daoLedger: 515
+    daoLedger: 515,
+    kolibriLedger: 380,
+    hDaoSwap: "KT1V41fGzkdTJki4d11T1Rp9yPkCmDhB7jph", 
+    kolibriSwap: "KT1CiSKXR68qYSxnbzjwvfeMCRburaSDonT2",
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -153,14 +153,19 @@ const randomFeed = async (counter, res) => {
     })
 }
 
-const getFeed = async (counter, res) => {
+const getFeed = async (counter, res, featured) => {
 
     /*     const now_time = Date.now()
         const immutable = (typeof max_time !== 'undefined') && (max_time < now_time)
         max_time = (typeof max_time !== 'undefined') ? max_time : customFloor(now_time, ONE_MINUTE_MILLIS)
      */
     console.log('feed')
-    var arr = await conseilUtil.getArtisticUniverse(0)
+    var arr
+    if (featured) {
+        arr = await conseilUtil.getFeaturedArtisticUniverse(0)
+    } else {
+        arr = await conseilUtil.getArtisticUniverse(0)
+    }
 
     var feed = offset(desc(arr), counter)
     console.log(feed)
@@ -302,7 +307,19 @@ app.post('/feed', async (req, res) => {
             max_time = null
         } 
     */
-    await getFeed(req.body.counter, res)
+    await getFeed(req.body.counter, res, true)
+})
+
+app.post('/all', async (req, res) => {
+    /*     
+        var counter = req.query.counter
+        var max_time = req.query.hasOwnProperty('time') ? customFloor(req.query.time, ONE_MINUTE_MILLIS) : null
+        const now_time_qt = customFloor(Date.now(), ONE_MINUTE_MILLIS)
+        if (max_time != null & max_time > now_time_qt) {
+            max_time = null
+        } 
+    */
+    await getFeed(req.body.counter, res, false)
 })
 
 app.post('/random', async (req, res) => {
@@ -341,6 +358,6 @@ app.post('/hdao', async (req, res) => {
 const testhdao = async () =>  await hDAOFeed(parseInt(0))
 //testhdao()
 
-//app.listen(3001)
-module.exports.handler = serverless(app)
+app.listen(3001)
+//module.exports.handler = serverless(app)
 

--- a/index.js
+++ b/index.js
@@ -298,7 +298,7 @@ const app = express()
 app.use(express.json())
 app.use(cors({ origin: '*' }))
 
-app.post('/feed', async (req, res) => {
+app.post('/featured', async (req, res) => {
     /*     
         var counter = req.query.counter
         var max_time = req.query.hasOwnProperty('time') ? customFloor(req.query.time, ONE_MINUTE_MILLIS) : null
@@ -310,7 +310,7 @@ app.post('/feed', async (req, res) => {
     await getFeed(req.body.counter, res, true)
 })
 
-app.post('/all', async (req, res) => {
+app.post('/feed', async (req, res) => {
     /*     
         var counter = req.query.counter
         var max_time = req.query.hasOwnProperty('time') ? customFloor(req.query.time, ONE_MINUTE_MILLIS) : null

--- a/index.js
+++ b/index.js
@@ -351,6 +351,11 @@ app.post('/objkt', async (req, res) => {
         res.json({ result: await getObjktById(req.body.objkt_id) })
 })
 
+app.get('/recommend_curate', async (req, res) => {
+    const amt = await conseilUtil.getRecommendedCurateDefault()
+    res.json({ amount: amt })
+})
+
 app.post('/hdao', async (req, res) => {
     await hDAOFeed(parseInt(req.body.counter), res)
 })

--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ const getFeed = async (counter, res, featured) => {
         const immutable = (typeof max_time !== 'undefined') && (max_time < now_time)
         max_time = (typeof max_time !== 'undefined') ? max_time : customFloor(now_time, ONE_MINUTE_MILLIS)
      */
-    console.log('feed')
+    console.log(`feed, featured: ${featured}`)
     var arr
     if (featured) {
         arr = await conseilUtil.getFeaturedArtisticUniverse(0)

--- a/index.js
+++ b/index.js
@@ -358,6 +358,6 @@ app.post('/hdao', async (req, res) => {
 const testhdao = async () =>  await hDAOFeed(parseInt(0))
 //testhdao()
 
-app.listen(3001)
-//module.exports.handler = serverless(app)
+//app.listen(3001)
+module.exports.handler = serverless(app)
 


### PR DESCRIPTION
We still struggle with copyminters and spammers, this introduces a new feed that has less of it and it is relative to the amount of mints within the last week, meaning bot-accounts that mint 100+ mints per week also will not show up.

Still, this change is quite radical, so I've also retained the old feed as /feed, which should be implemented in the UI, but this should ideally be the default feed.

We can decide later which we want as the default, but for now this new feed is under /featured

For now this threshold is: (User hDAO / (max(1, mints this week) )) > 1 hDAO (1_000_000 nat)