### PR TITLE
Correct creations list sort order

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,6 +224,8 @@ const getTzLedger = async (tz, res) => {
         return arr
     }))
 
+    validCreations = validCreations.sort((a, b) => parseInt(b.objectId) - parseInt(a.objectId))
+
     var arr = []
     console.log([...collection, ...validCreations])
     var arr = [...collection, ...validCreations]


### PR DESCRIPTION
This PR corrects the ordering of the creation list after removing burned objkts. This was caused by the async nature of Promise.all combined with re populating the collections array.