### PR TITLE
Simple feed caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lodash": "^4.17.21",
     "loglevel": "1.7.1",
     "node-fetch": "2.6.1",
+    "prex": "^0.4.7",
     "serverless-dotenv-plugin": "^3.8.1",
     "serverless-http": "^2.7.0"
   },


### PR DESCRIPTION
Very simple implementation of caching for the feed request. It should save many calls to the API when the site has high traffic, and make the initial page load a lot faster too.

A semaphore could be added to make sure that there was never more than 1 API call every 10 seconds in the case that it was refreshing the cache with multiple calls at the same time.