### PR TITLE
Simple feed / featured / ban list caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lodash": "^4.17.21",
     "loglevel": "1.7.1",
     "node-fetch": "2.6.1",
+    "prex": "^0.4.7",
     "serverless-dotenv-plugin": "^3.8.1",
     "serverless-http": "^2.7.0"
   },


### PR DESCRIPTION
Implemented simple caching that lasts 1 minute for:

- /feed - supports offset for paging
- /featured - supports offset for paging
- o.json and w.json ban lists

This is a temporary fix to speed the site up before a rewrite. It should both minimize load times on the feed and make the Lambdas less expensive to run.

Also note this could be implemented for the hDAO feed as well.

Implementing for random would need caching of the `getUniverse` call which is a whole different thing and should wait until a rewrite is complete. That said, it could be easy to implement a set of randoms ie have a bucket of 10 random caches that can only be updated once a minute. On each request show data from one of these caches, unless it has expired. This way you could click random a few times a minute and it would still be fast.