### PR TITLE
Feature - add swagger docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@ Swagger docs generated using [swagger-autogen](https://github.com/davibaltar/swa
 ```
 GET /doc
 ```
+
+If you add or amend the API endpoints, please also update the swagger definitions, and regenerate the docs:
+
+```
+npm run swagger-autogen
+```

--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ POST /tz :tz
 POST /objkt :objkt_id
 POST /hdao :counter
 ```
+
+## API documentation
+
+Swagger docs generated using [swagger-autogen](https://github.com/davibaltar/swagger-autogen). These allow you to test and view the API responses.
+
+```
+GET /doc
+```

--- a/index.js
+++ b/index.js
@@ -208,15 +208,12 @@ const feedfeatured = async(req, res) => {
 }
 
 app.post('/feed|/featured', async (req, res) => {
-    /*  #swagger.start
-        #wagger.auto = false
+    /*  
+        #swagger.start
         #swagger.path = '/feed/{featured}'
         #swagger.method = 'post'
         #swagger.summary = 'Main feed'
-        #swagger.description = 'Endpoint used to return the most recently minted OBJKTs.
-            Data is returned 30 at a time, and can be paginated. Total results are limited to 2500.
-            Use of the optional `featured` path parameter will apply a different filter to the
-            feed.'
+        #swagger.description = 'Endpoint used to return the most recently minted OBJKTs. Data is returned 30 at a time, and can be paginated. Total results are limited to 2500. Use of the optional `featured` path parameter will apply a different filter to the feed.'
         #swagger.parameters['featured'] = {
             in: 'path',
             type: 'string',
@@ -246,6 +243,13 @@ app.post('/feed|/featured', async (req, res) => {
 })
 
 app.get('/feed|/featured', async (req, res) => {
+    /*  
+        #swagger.start
+        #swagger.path = '/feed/{featured}'
+        #swagger.method = 'get'
+        #swagger.summary = 'Main feed (works in same way as `POST /feed`)'
+        #swagger.end
+    */
     await feedfeatured(req, res)
 })
 
@@ -261,6 +265,9 @@ app.post('/random', async (req, res) => {
 })
 
 app.get('/random', async (req, res) => {
+    /* #swagger.summary = 'Random OBJKTs'
+       #swagger.description = 'Endpoint used to return an array of a random set of OBJKTs. Works in same way as `POST /random`'
+    */
     res.set('Cache-Control', `public, max-age=300`)
     await randomFeed(parseInt(req.query.counter), res)
 })
@@ -280,9 +287,19 @@ const get_tz = async(tz, res) => {
 }
 
 app.post('/tz', async (req, res) => {
+    /* #swagger.summary = 'Account information'
+       #swagger.description = 'Endpoint used to return information about a wallet address. This
+       includes the OBJKTs that wallet created, those that it holds, and the amount of hDAO it
+       holds. Data is returned 30 at a time, and can be paginated. Total results are limited to 2500.'
+    */
     await get_tz(req.body.tz, res)
 })
 app.get('/tz', async (req, res) => {
+    /* #swagger.summary = 'Account information'
+       #swagger.description = 'Endpoint used to return information about a wallet address. This
+       includes the OBJKTs that wallet created, those that it holds, and the amount of hDAO it
+       holds. Data is returned 30 at a time, and can be paginated. Total results are limited to 2500.'
+    */
     await get_tz(req.query.tz, res)
 })
 
@@ -303,12 +320,15 @@ const objkt = async(id, res) => {
 
 app.post('/objkt', async (req, res) => {
     /* #swagger.summary = 'OBJKT details'
-       #swagger.description = 'Endpoint used to return information about an OBJKT.'
+       #swagger.description = 'Endpoint used to return detailed information about an OBJKT.'
     */
     await objkt(req.body.objkt_id, res)
 
 })
 app.get('/objkt', async (req, res) => {
+    /* #swagger.summary = 'OBJKT details'
+       #swagger.description = 'Endpoint used to return detailed information about an OBJKT.'
+    */
     await objkt(req.query.id, res)
 })
 
@@ -316,6 +336,11 @@ app.get('/objkt', async (req, res) => {
 
 
 app.get('/recommend_curate', async (req, res) => {
+    /* #swagger.summary = 'hDAO minimum spend recommendation'
+       #swagger.description = 'Endpoint determines the current swap prices between these currency pairs
+        (USD:hDAO, XTZ:hDAO), and it calculates the hDAO value of them. This value is returned if larger
+        than 0.1 hDAO, else 0.1 is returned. This data is cached for 300s.
+    */    
     const amt = await conseilUtil.getRecommendedCurateDefault()
     res.set('Cache-Control', `public, max-age=300`)
     res.json({ amount: amt })
@@ -324,10 +349,20 @@ app.get('/recommend_curate', async (req, res) => {
 
 // HDAO
 app.post('/hdao', async (req, res) => {
+    /* #swagger.summary = 'hDAO feed'
+       #swagger.description = 'Endpoint used to return the list of OBJKTs with hDAO in descending
+       order of how many hDAO have been spend on them. Data is returned 30 at a time, and can be
+       paginated. Total results are limited to 30000.'
+    */
     await hDAOFeed(parseInt(req.body.counter), res)
 })
 
 app.get('/hdao', async (req, res) => {
+    /* #swagger.summary = 'hDAO feed'
+       #swagger.description = 'Endpoint used to return the list of OBJKTs with hDAO in descending
+       order of how many hDAO have been spend on them. Data is returned 30 at a time, and can be
+       paginated. Total results are limited to 30000.'
+    */
     await hDAOFeed(parseInt(req.query.counter), res)
 })
 

--- a/index.js
+++ b/index.js
@@ -251,9 +251,9 @@ app.post('/feed|/featured', async (req, res) => {
     /*  #swagger.start
         #wagger.auto = false
         #swagger.path = '/feed/{featured}'
-        #swagger.method = 'post'        
+        #swagger.method = 'post'
         #swagger.summary = 'Main feed'
-        #swagger.description = 'Endpoint used to return the most recently minted OBJKTs. 
+        #swagger.description = 'Endpoint used to return the most recently minted OBJKTs.
             Data is returned 30 at a time, and can be paginated. Total results are limited to 2500.
             Use of the optional `featured` path parameter will apply a different filter to the
             feed.'
@@ -283,31 +283,6 @@ app.post('/feed|/featured', async (req, res) => {
         #swagger.end
     */
 
-    /*  #swagger.start
-        #swagger.auto = false
-        #swagger.path = '/feed/featured'
-        #swagger.method = 'post'        
-        #swagger.summary = 'Main feed (cached)'
-        #swagger.description = 'Endpoint used to return a featured set of recently minted OBJKTs, 
-            no more than 1 item per minter, less than 0.1 tez and that hasn't been updated with 
-            lots of hDAO. Data is returned 30 at a time, and can be paginated. Total results are 
-            limited to 2500.'
-        #swagger.parameters['counter'] = {
-            in: 'body',
-            description: 'Pagination number. Default is 0',
-            required: false,
-            type: 'number',
-            schema: { "counter": 0 }
-        }
-        #swagger.responses[200] = {
-            schema: {
-                "result": [
-                    { $ref: "#/definitions/objkt" }
-                ]
-            }
-        }
-        #swagger.end
-    */
     const feedOffset = req.body.counter || 0
     const isFeatured = req.path === '/featured'
     const lockKey = `${feedOffset}-${isFeatured ? 'featured' : ''}`

--- a/index.js
+++ b/index.js
@@ -261,7 +261,7 @@ app.post('/feed|/featured', async (req, res) => {
             in: 'path',
             type: 'string',
             description: 'Applies a filter to the results - returning no more than 1 item per minter,
-                including only those swapped for less than 0.1 tez and that haven\'t been updated with 
+                including only those swapped for less than 0.1 tez and that haven\'t been updated with
                 lots of hDAO.',
             required: false,
             schema: 'featured'
@@ -356,8 +356,8 @@ app.post('/hdao', async (req, res) => {
 app.use(express.json())
 app.use('/doc', swaggerUi.serve, swaggerUi.setup(swaggerFile))
 
-app.listen(3001)
+//app.listen(3001)
 console.log('SERVER RUNNING ON localhost:3001')
 console.log('API documentation: http://localhost:3001/doc')
-//module.exports.handler = serverless(app)
+module.exports.handler = serverless(app)
 

--- a/index.js
+++ b/index.js
@@ -354,7 +354,13 @@ app.post('/hdao', async (req, res) => {
 
 //generate swagger docs endpoint
 app.use(express.json())
-app.use('/doc', swaggerUi.serve, swaggerUi.setup(swaggerFile))
+var swaggerOptions = {
+    explorer: true,
+    defaultModelsExpandDepth: -1,
+    customCssUrl: 'https://cdn.jsdelivr.net/npm/swagger-ui-themes@3.0.0/themes/3.x/theme-newspaper.css',
+    customCss: '.swagger-ui .topbar { display: none } '
+  };
+app.use('/doc', swaggerUi.serve, swaggerUi.setup(swaggerFile, swaggerOptions))
 
 //app.listen(3001)
 console.log('SERVER RUNNING ON localhost:3001')

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const cors = require('cors')
 const _ = require('lodash')
 const conseilUtil = require('./conseilUtil')
 const { random } = require('lodash')
+const swaggerUi = require('swagger-ui-express')
+const swaggerFile = require('./swagger-output.json')
 
 const BURN_ADDRESS = 'tz1burnburnburnburnburnburnburjAYjjX'
 
@@ -246,6 +248,66 @@ const getFeedLock = (key) => {
 }
 
 app.post('/feed|/featured', async (req, res) => {
+    /*  #swagger.start
+        #wagger.auto = false
+        #swagger.path = '/feed/{featured}'
+        #swagger.method = 'post'        
+        #swagger.summary = 'Main feed'
+        #swagger.description = 'Endpoint used to return the most recently minted OBJKTs. 
+            Data is returned 30 at a time, and can be paginated. Total results are limited to 2500.
+            Use of the optional `featured` path parameter will apply a different filter to the
+            feed.'
+        #swagger.parameters['featured'] = {
+            in: 'path',
+            type: 'string',
+            description: 'Applies a filter to the results - returning no more than 1 item per minter,
+                including only those swapped for less than 0.1 tez and that haven\'t been updated with 
+                lots of hDAO.',
+            required: false,
+            schema: 'featured'
+        }
+        #swagger.parameters['counter'] = {
+            in: 'body',
+            description: 'Pagination number. Default is 0',
+            required: false,
+            type: 'number',
+            schema: { "counter": 0 }
+        }
+        #swagger.responses[200] = {
+            schema: {
+                "result": [
+                    { $ref: "#/definitions/objkt" }
+                ]
+            }
+        }
+        #swagger.end
+    */
+
+    /*  #swagger.start
+        #swagger.auto = false
+        #swagger.path = '/feed/featured'
+        #swagger.method = 'post'        
+        #swagger.summary = 'Main feed (cached)'
+        #swagger.description = 'Endpoint used to return a featured set of recently minted OBJKTs, 
+            no more than 1 item per minter, less than 0.1 tez and that hasn't been updated with 
+            lots of hDAO. Data is returned 30 at a time, and can be paginated. Total results are 
+            limited to 2500.'
+        #swagger.parameters['counter'] = {
+            in: 'body',
+            description: 'Pagination number. Default is 0',
+            required: false,
+            type: 'number',
+            schema: { "counter": 0 }
+        }
+        #swagger.responses[200] = {
+            schema: {
+                "result": [
+                    { $ref: "#/definitions/objkt" }
+                ]
+            }
+        }
+        #swagger.end
+    */
     const feedOffset = req.body.counter || 0
     const isFeatured = req.path === '/featured'
     const lockKey = `${feedOffset}-${isFeatured ? 'featured' : ''}`
@@ -268,6 +330,9 @@ app.post('/feed|/featured', async (req, res) => {
 })
 
 app.post('/random', async (req, res) => {
+    /* #swagger.summary = 'Random OBJKTs'
+       #swagger.description = 'Endpoint used to return an array of a random set of OBJKTs.'
+    */
     await randomFeed(parseInt(req.body.counter), res)
 })
 
@@ -285,6 +350,9 @@ app.post('/tz', async (req, res) => {
 })
 
 app.post('/objkt', async (req, res) => {
+    /* #swagger.summary = 'OBJKT details'
+       #swagger.description = 'Endpoint used to return information about an OBJKT.'
+    */
 
     // list of restricted objkts
     var list = await getRestrictedObjkts()
@@ -309,7 +377,12 @@ app.post('/hdao', async (req, res) => {
 // const testhdao = async () =>  await hDAOFeed(parseInt(0))
 //testhdao()
 
-//app.listen(3001)
+//generate swagger docs endpoint
+app.use(express.json())
+app.use('/doc', swaggerUi.serve, swaggerUi.setup(swaggerFile))
+
+app.listen(3001)
 console.log('SERVER RUNNING ON localhost:3001')
-module.exports.handler = serverless(app)
+console.log('API documentation: http://localhost:3001/doc')
+//module.exports.handler = serverless(app)
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "description": "",
     "main": "index.js",
     "scripts": {
-        "start": "node index.js"
+        "start": "node index.js",
+        "swagger-autogen": "node swagger.js"
     },
     "repository": {
         "type": "git",
@@ -30,7 +31,9 @@
         "node-fetch": "2.6.1",
         "prex": "^0.4.7",
         "serverless-dotenv-plugin": "^3.8.1",
-        "serverless-http": "^2.7.0"
+        "serverless-http": "^2.7.0",
+        "swagger-autogen": "^2.7.8",
+        "swagger-ui-express": "^4.1.6"
     },
     "engines": {
         "node": "12.20.1",

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Hic et Nunc API",
-    "description": "This API is used as the backend for https://hicetnunc.xyz. It consumes information from a number of Tezos blockchain information providers, including https://cryptonomic.github.io/ConseilJS/  and https://better-call.dev/docs, along with objkt metadata sourced from IPFS",
+    "description": "This API is used as the backend for https://hicetnunc.xyz. It consumes information from a number of Tezos blockchain information providers, including https://cryptonomic.github.io/ConseilJS/ and https://better-call.dev/docs, along with objkt metadata sourced from IPFS",
     "version": "1.0.0"
   },
   "host": "localhost:3001",
@@ -18,14 +18,14 @@
       "post": {
         "tags": [],
         "summary": "Main feed",
-        "description": "Endpoint used to return the most recently minted OBJKTs.   Data is returned 30 at a time, and can be paginated. Total results are limited to 2500.  Use of the optional `featured` path parameter will apply a different filter to the  feed.",
+        "description": "Endpoint used to return the most recently minted OBJKTs.  Data is returned 30 at a time, and can be paginated. Total results are limited to 2500.  Use of the optional `featured` path parameter will apply a different filter to the  feed.",
         "parameters": [
           {
             "name": "featured",
             "in": "path",
             "required": false,
             "type": "string",
-            "description": "Applies a filter to the results - returning no more than 1 item per minter,  including only those swapped for less than 0.1 tez and that haven't been updated with   lots of hDAO.",
+            "description": "Applies a filter to the results - returning no more than 1 item per minter,  including only those swapped for less than 0.1 tez and that haven't been updated with  lots of hDAO.",
             "schema": {
               "type": "string",
               "example": "featured"
@@ -165,50 +165,6 @@
           }
         ],
         "responses": {}
-      }
-    },
-    "/feed/featured": {
-      "post": {
-        "tags": [],
-        "summary": "Main feed (cached)",
-        "description": "Endpoint used to return a featured set of recently minted OBJKTs,   no more than 1 item per minter, less than 0.1 tez and that hasn",
-        "parameters": [
-          {
-            "name": "counter",
-            "in": "body",
-            "description": "Pagination number. Default is 0",
-            "required": false,
-            "type": "number",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "counter": {
-                  "type": "number",
-                  "example": 0
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "result": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/objkt"
-                  }
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
-            },
-            "description": "OK"
-          }
-        }
       }
     }
   },

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -9,7 +9,8 @@
   "basePath": "/",
   "tags": [],
   "schemes": [
-    "https"
+    "https",
+    "http"
   ],
   "consumes": [],
   "produces": [],

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -19,7 +19,7 @@
       "post": {
         "tags": [],
         "summary": "Main feed",
-        "description": "Endpoint used to return the most recently minted OBJKTs.  Data is returned 30 at a time, and can be paginated. Total results are limited to 2500.  Use of the optional `featured` path parameter will apply a different filter to the  feed.",
+        "description": "Endpoint used to return the most recently minted OBJKTs. Data is returned 30 at a time, and can be paginated. Total results are limited to 2500. Use of the optional `featured` path parameter will apply a different filter to the feed.",
         "parameters": [
           {
             "name": "featured",
@@ -68,6 +68,20 @@
             "description": "OK"
           }
         }
+      },
+      "get": {
+        "tags": [],
+        "summary": "Main feed",
+        "description": "",
+        "parameters": [
+          {
+            "name": "featured",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
       }
     },
     "/random": {
@@ -91,12 +105,26 @@
           }
         ],
         "responses": {}
+      },
+      "get": {
+        "tags": [],
+        "summary": "Random OBJKTs",
+        "description": "Endpoint used to return an array of a random set of OBJKTs.",
+        "parameters": [
+          {
+            "name": "counter",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "responses": {}
       }
     },
     "/tz": {
       "post": {
         "tags": [],
-        "description": "",
+        "summary": "Account information",
+        "description": "Endpoint used to return information about a wallet address. This  includes the OBJKTs that wallet created, those that it holds, and the amount of hDAO it  holds. Data is returned 30 at a time, and can be paginated. Total results are limited to 2500.",
         "parameters": [
           {
             "name": "obj",
@@ -113,13 +141,26 @@
           }
         ],
         "responses": {}
+      },
+      "get": {
+        "tags": [],
+        "summary": "Account information",
+        "description": "Endpoint used to return information about a wallet address. This  includes the OBJKTs that wallet created, those that it holds, and the amount of hDAO it  holds. Data is returned 30 at a time, and can be paginated. Total results are limited to 2500.",
+        "parameters": [
+          {
+            "name": "tz",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "responses": {}
       }
     },
     "/objkt": {
       "post": {
         "tags": [],
         "summary": "OBJKT details",
-        "description": "Endpoint used to return information about an OBJKT.",
+        "description": "Endpoint used to return detailed information about an OBJKT.",
         "parameters": [
           {
             "name": "obj",
@@ -136,11 +177,25 @@
           }
         ],
         "responses": {}
+      },
+      "get": {
+        "tags": [],
+        "summary": "OBJKT details",
+        "description": "Endpoint used to return detailed information about an OBJKT.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "responses": {}
       }
     },
     "/recommend_curate": {
       "get": {
         "tags": [],
+        "summary": "hDAO minimum spend recommendation",
         "description": "",
         "parameters": [],
         "responses": {}
@@ -149,7 +204,8 @@
     "/hdao": {
       "post": {
         "tags": [],
-        "description": "",
+        "summary": "hDAO feed",
+        "description": "Endpoint used to return the list of OBJKTs with hDAO in descending  order of how many hDAO have been spend on them. Data is returned 30 at a time, and can be  paginated. Total results are limited to 30000.",
         "parameters": [
           {
             "name": "obj",
@@ -163,6 +219,19 @@
                 }
               }
             }
+          }
+        ],
+        "responses": {}
+      },
+      "get": {
+        "tags": [],
+        "summary": "hDAO feed",
+        "description": "Endpoint used to return the list of OBJKTs with hDAO in descending  order of how many hDAO have been spend on them. Data is returned 30 at a time, and can be  paginated. Total results are limited to 30000.",
+        "parameters": [
+          {
+            "name": "counter",
+            "in": "query",
+            "type": "string"
           }
         ],
         "responses": {}

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -1,0 +1,344 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Hic et Nunc API",
+    "description": "This API is used as the backend for https://hicetnunc.xyz. It consumes information from a number of Tezos blockchain information providers, including https://cryptonomic.github.io/ConseilJS/  and https://better-call.dev/docs, along with objkt metadata sourced from IPFS",
+    "version": "1.0.0"
+  },
+  "host": "localhost:3001",
+  "basePath": "/",
+  "tags": [],
+  "schemes": [
+    "https"
+  ],
+  "consumes": [],
+  "produces": [],
+  "paths": {
+    "/feed/{featured}": {
+      "post": {
+        "tags": [],
+        "summary": "Main feed",
+        "description": "Endpoint used to return the most recently minted OBJKTs.   Data is returned 30 at a time, and can be paginated. Total results are limited to 2500.  Use of the optional `featured` path parameter will apply a different filter to the  feed.",
+        "parameters": [
+          {
+            "name": "featured",
+            "in": "path",
+            "required": false,
+            "type": "string",
+            "description": "Applies a filter to the results - returning no more than 1 item per minter,  including only those swapped for less than 0.1 tez and that haven't been updated with   lots of hDAO.",
+            "schema": {
+              "type": "string",
+              "example": "featured"
+            }
+          },
+          {
+            "name": "counter",
+            "in": "body",
+            "description": "Pagination number. Default is 0",
+            "required": false,
+            "type": "number",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "counter": {
+                  "type": "number",
+                  "example": 0
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/objkt"
+                  }
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/random": {
+      "post": {
+        "tags": [],
+        "summary": "Random OBJKTs",
+        "description": "Endpoint used to return an array of a random set of OBJKTs.",
+        "parameters": [
+          {
+            "name": "obj",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "counter": {
+                  "type": "string",
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/tz": {
+      "post": {
+        "tags": [],
+        "description": "",
+        "parameters": [
+          {
+            "name": "obj",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "tz": {
+                  "type": "string",
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/objkt": {
+      "post": {
+        "tags": [],
+        "summary": "OBJKT details",
+        "description": "Endpoint used to return information about an OBJKT.",
+        "parameters": [
+          {
+            "name": "obj",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "objkt_id": {
+                  "type": "string",
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/recommend_curate": {
+      "get": {
+        "tags": [],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/hdao": {
+      "post": {
+        "tags": [],
+        "description": "",
+        "parameters": [
+          {
+            "name": "obj",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "counter": {
+                  "type": "string",
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/feed/featured": {
+      "post": {
+        "tags": [],
+        "summary": "Main feed (cached)",
+        "description": "Endpoint used to return a featured set of recently minted OBJKTs,   no more than 1 item per minter, less than 0.1 tez and that hasn",
+        "parameters": [
+          {
+            "name": "counter",
+            "in": "body",
+            "description": "Pagination number. Default is 0",
+            "required": false,
+            "type": "number",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "counter": {
+                  "type": "number",
+                  "example": 0
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/objkt"
+                  }
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "objkt": {
+      "type": "object",
+      "properties": {
+        "objectId": {
+          "type": "string",
+          "example": "24043"
+        },
+        "ipfsHash": {
+          "type": "string",
+          "example": "QmXx8hY7nh41bFzEfXW1iiiKcEBJgsdkjvtMvP2Xj3o2Z7"
+        },
+        "minter": {
+          "type": "string",
+          "example": "tz1eT35U51k1FxduLgFFTqrcYV4b6LRtTvUr"
+        },
+        "swaps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/swap"
+          }
+        },
+        "token_info": {
+          "$ref": "#/definitions/token_info"
+        },
+        "token_id": {
+          "type": "string",
+          "example": "24043"
+        }
+      }
+    },
+    "swap": {
+      "type": "object",
+      "properties": {
+        "swap_id": {
+          "type": "string",
+          "example": "24043"
+        },
+        "objkt_id": {
+          "type": "string",
+          "example": "20987"
+        },
+        "amount": {
+          "type": "string",
+          "example": "14"
+        },
+        "xtz_per_objkt": {
+          "type": "string",
+          "example": "1000000"
+        }
+      }
+    },
+    "token_info": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "Neonland II"
+        },
+        "description": {
+          "type": "string",
+          "example": "Circle"
+        },
+        "tags": {
+          "type": "array",
+          "example": [
+            "neon",
+            "circle"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "symbol": {
+          "type": "string",
+          "example": "OBJKT"
+        },
+        "artifactUri": {
+          "type": "string",
+          "example": "ipfs://QmewqUfDNPf8ZV51Awwhs62nkEVHk6fBcivtEVZvpLn5Vi"
+        },
+        "displayUri": {
+          "type": "string",
+          "example": ""
+        },
+        "creators": {
+          "type": "array",
+          "example": [
+            "tz1eT35U51k1FxduLgFFTqrcYV4b6LRtTvUr"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "formats": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "uri": {
+                "type": "string",
+                "example": "ipfs://QmewqUfDNPf8ZV51Awwhs62nkEVHk6fBcivtEVZvpLn5Vi"
+              },
+              "mimeType": {
+                "type": "string",
+                "example": "image/png"
+              }
+            }
+          }
+        },
+        "thumbnailUri": {
+          "type": "string",
+          "example": "ipfs://QmNrhZHUaEqxhyLfqoq1mtHSipkWHeT31LNHb1QEbDHgnc"
+        },
+        "decimals": {
+          "type": "number",
+          "example": 0
+        },
+        "isBooleanAmount": {
+          "type": "boolean",
+          "example": false
+        },
+        "shouldPreferSymbol": {
+          "type": "boolean",
+          "example": false
+        }
+      }
+    }
+  }
+}

--- a/swagger.js
+++ b/swagger.js
@@ -1,0 +1,59 @@
+const swaggerAutogen = require('swagger-autogen')()
+
+const doc = {
+  info: {
+      title: "Hic et Nunc API",
+      description: "This API is used as the backend for https://hicetnunc.xyz. It consumes information from a number of Tezos blockchain information providers, including https://cryptonomic.github.io/ConseilJS/ and https://better-call.dev/docs, along with objkt metadata sourced from IPFS"
+  },
+  host: "localhost:3001",
+  schemes: ['https'],
+  definitions: {
+    objkt: {
+      "objectId": "24043",
+      "ipfsHash": "QmXx8hY7nh41bFzEfXW1iiiKcEBJgsdkjvtMvP2Xj3o2Z7",
+      "minter": "tz1eT35U51k1FxduLgFFTqrcYV4b6LRtTvUr",
+      "swaps": [{ $ref: "#/definitions/swap" }],
+      "token_info": { $ref: "#/definitions/token_info"},
+      "token_id": "24043"
+    },
+    swap: {
+      "swap_id": "24043",
+      "objkt_id": "20987",
+      "amount": "14",
+      "xtz_per_objkt": "1000000"
+    },
+    token_info: {
+      "name": "Neonland II",
+      "description": "Circle",
+      "tags": [
+          "neon",
+          "circle"
+      ],
+      "symbol": "OBJKT",
+      "artifactUri": "ipfs://QmewqUfDNPf8ZV51Awwhs62nkEVHk6fBcivtEVZvpLn5Vi",
+      "displayUri": "",
+      "creators": [
+          "tz1eT35U51k1FxduLgFFTqrcYV4b6LRtTvUr"
+      ],
+      "formats": [
+          {
+              "uri": "ipfs://QmewqUfDNPf8ZV51Awwhs62nkEVHk6fBcivtEVZvpLn5Vi",
+              "mimeType": "image/png"
+          }
+      ],
+      "thumbnailUri": "ipfs://QmNrhZHUaEqxhyLfqoq1mtHSipkWHeT31LNHb1QEbDHgnc",
+      "decimals": 0,
+      "isBooleanAmount": false,
+      "shouldPreferSymbol": false
+    }
+  }
+}
+
+const outputFile = './swagger-output.json'
+const endpointsFiles = ['./index.js']
+
+/* NOTE: if you use the express Router, you must pass in the 
+   'endpointsFiles' only the root file where the route starts,
+   such as: index.js, app.js, routes.js, ... */
+
+swaggerAutogen(outputFile, endpointsFiles, doc)

--- a/swagger.js
+++ b/swagger.js
@@ -6,7 +6,7 @@ const doc = {
       description: "This API is used as the backend for https://hicetnunc.xyz. It consumes information from a number of Tezos blockchain information providers, including https://cryptonomic.github.io/ConseilJS/ and https://better-call.dev/docs, along with objkt metadata sourced from IPFS"
   },
   host: "localhost:3001",
-  schemes: ['https'],
+  schemes: ['https','http'],
   definitions: {
     objkt: {
       "objectId": "24043",


### PR DESCRIPTION
Add first draft of swagger docs. Only one of the APIs is fully documented, just to get some feedback for this PR.

The docs are generated using [swagger-autogen](https://github.com/davibaltar/swagger-autogen) based on comments added to each of the main endpoint methods. The generated file allows you to test the API with different parameters and view results.

![chrome-capture](https://user-images.githubusercontent.com/510285/114175582-0074c800-9932-11eb-9822-b2014bca830a.gif)

Implements #21 