### PR TITLE
Add blocked wallet API endpoint

### DIFF
--- a/lib/router/readBlocklists.js
+++ b/lib/router/readBlocklists.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const { getRestrictedAddresses } = require('./../utils')
+
+module.exports = async function readBlocklists(req, res) {
+  const wallet = req.query.tz
+  const restrictedAddresses =  await getRestrictedAddresses().catch(() => [] )
+
+  if (restrictedAddresses && !restrictedAddresses.includes(wallet)) {
+    return res
+      .status(200)
+      .json({blocked: false})
+  } else {
+    res
+      .status(200)
+      .json({blocked: true})
+  }
+}

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -7,6 +7,7 @@ const readIssuer = require('./readIssuer')
 const readObjkt = require('./readObjkt')
 const readHdaoFeed = require('./readHdaoFeed')
 const readRecommendCurate = require('./readRecommendCurate')
+const readBlocklists = require('./readBlocklists')
 
 const MILLISECOND_MODIFIER = 1000
 const ONE_MINUTE_MILLIS = 60 * MILLISECOND_MODIFIER
@@ -18,6 +19,7 @@ const CACHE_MAX_AGE_MAP = {
   objkt: 120,
   random: 300,
   recommendCurate: 300,
+  blocklists: 300,
 }
 
 router
@@ -94,6 +96,16 @@ router.get(
     return next()
   },
   _asyncHandler(readRecommendCurate)
+)
+
+router.get(
+  '/blocklist',
+  (req, res, next) => {
+    _setCacheHeaderOnSuccess(res, CACHE_MAX_AGE_MAP.blocklists)
+
+    return next()
+  },
+  _asyncHandler(readBlocklists)
 )
 
 module.exports = router


### PR DESCRIPTION
This endpoints allows interactive NFTs to access the blocked wallet lists as the HEN API domain can be accessed from within the iframe sandbox.

It could probably do with extending error handling for missing/invalid parameter (400) or the github file being unavailable (503).

```
$ curl localhost:3001/blocklist?tz=tz1RBogZUNv2XJnTzArQJxc4KkvL5nT2kEMb
{"blocked":true}

$ curl localhost:3001/blocklist?tz=foo
{"blocked":false}

$ curl localhost:3001/blocklist
{"blocked":false}
```