### PR TITLE
Feature - add swagger docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,17 @@ POST /tz :tz
 POST /objkt :objkt_id
 POST /hdao :counter
 ```
+
+## API documentation
+
+Swagger docs generated using [swagger-autogen](https://github.com/davibaltar/swagger-autogen). These allow you to test and view the API responses.
+
+```
+GET /docs
+```
+
+If you add or amend the API endpoints, please also update the swagger definitions, and regenerate the docs:
+
+```
+npm run swagger-autogen
+```

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -135,20 +135,26 @@ router
   .route('/tz')
   .all((req, res, next) => {
     _setCacheHeaderOnSuccess(res, CACHE_MAX_AGE_MAP.issuer)
+
+    return next()
+  })
+  .get((req, res, next) => {
     /* #swagger.summary = 'Account information'
        #swagger.description = 'Endpoint used to return information about a wallet address. This
        includes the OBJKTs that wallet created, those that it holds, and the amount of hDAO it
        holds. Data is returned 30 at a time, and can be paginated. Total results are limited to 2500.'
     */
-
-    return next()
-  })
-  .get((req, res, next) => {
     req.body.tz = req.query.tz
 
     return next()
   }, _asyncHandler(readIssuer))
-  .post(_asyncHandler(readIssuer))
+  .post(_asyncHandler(readIssuer), () => {
+    /* #swagger.summary = 'Account information'
+       #swagger.description = 'Endpoint used to return information about a wallet address. This
+       includes the OBJKTs that wallet created, those that it holds, and the amount of hDAO it
+       holds. Data is returned 30 at a time, and can be paginated. Total results are limited to 2500.'
+    */
+  })
 
 router
   .route('/objkt')
@@ -158,11 +164,18 @@ router
     return next()
   })
   .get((req, res, next) => {
+    /* #swagger.summary = 'OBJKT details'
+       #swagger.description = 'Endpoint used to return detailed information about an OBJKT.'
+    */
     req.body.objkt_id = req.query.id
 
     return next()
   }, _asyncHandler(readObjkt))
-  .post(_asyncHandler(readObjkt))
+  .post(_asyncHandler(readObjkt), () => {
+    /* #swagger.summary = 'OBJKT details'
+       #swagger.description = 'Endpoint used to return detailed information about an OBJKT.'
+    */
+  })
 
 router
   .route('/hdao')
@@ -172,15 +185,46 @@ router
     return next()
   })
   .get((req, res, next) => {
+    /*  #swagger.summary = 'hDAO feed'
+        #swagger.description = 'Endpoint used to return the list of OBJKTs with hDAO in descending
+        order of how many hDAO have been spend on them. Data is returned 30 at a time, and can be
+        paginated. Total results are limited to 30000.'
+        #swagger.parameters['counter'] = {
+          in: 'querystring',
+          description: 'Results page count (default 0)',
+          type: 'number',
+          required: false
+        }
+       */
     req.body.counter = req.query.counter
 
     return next()
   }, _asyncHandler(readHdaoFeed))
-  .post(_asyncHandler(readHdaoFeed))
+  .post((req, res, next) => {
+    /*  #swagger.summary = 'hDAO feed'
+        #swagger.description = 'Endpoint used to return the list of OBJKTs with hDAO in descending
+        order of how many hDAO have been spend on them. Data is returned 30 at a time, and can be
+        paginated. Total results are limited to 30000.'
+        #swagger.parameters['counter'] = {
+          in: 'body',
+          description: 'Results page count (default 0)',
+          type: 'number',
+          required: false,
+          schema: { "counter": 0 }
+        }
+    */
+
+    return next()
+  }, _asyncHandler(readHdaoFeed))
 
 router.get(
   '/recommend_curate',
   (req, res, next) => {
+    /* #swagger.summary = 'hDAO minimum spend recommendation'
+       #swagger.description = 'Endpoint determines the current swap prices between these currency pairs
+        (USD:hDAO, XTZ:hDAO), and it calculates the hDAO value of them. This value is returned if larger
+        than 0.1 hDAO, else 0.1 is returned. This data is cached for 300s.
+    */    
     _setCacheHeaderOnSuccess(res, CACHE_MAX_AGE_MAP.recommendCurate)
 
     return next()

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -196,7 +196,7 @@ var swaggerOptions = {
   customCss: '.swagger-ui .topbar { display: none } '
 };
 router.use('/docs', swaggerUi.serve)
-router.get('/docs', swaggerUi.setup(swaggerDocument, swaggerOptions))
+router.get('/docs', swaggerUi.setup(swaggerDocument, swaggerOptions) /* #swagger.ignore = true */ ) 
 
 module.exports = router
 

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const router = require('express').Router()
+const swaggerUi = require('swagger-ui-express');
+const swaggerDocument = require('../../swagger-output.json');
 const readFeed = require('./readFeed')
 const readRandomFeed = require('./readRandomFeed')
 const readIssuer = require('./readIssuer')
@@ -24,12 +26,89 @@ router
   .route('/feed|/featured')
   .all(_processClientCache)
   .get((req, res, next) => {
+        /*  
+        #swagger.start
+        #swagger.path = '/feed/{featured}'
+        #swagger.method = 'get'
+        #swagger.summary = 'Main feed'
+        #swagger.description = 'Endpoint used to return the most recently minted OBJKTs. Data is returned 30 at a time, and can be paginated. Total results are limited to 2500. Use of the optional `featured` path parameter will apply a different filter to the feed.'
+        #swagger.parameters['featured'] = {
+            in: 'path',
+            type: 'string',
+            description: 'Applies a filter to the results - returning no more than 1 item per minter,
+                including only those swapped for less than 0.1 tez and that haven\'t been updated with
+                lots of hDAO.',
+            required: false,
+            schema: 'featured'
+        }
+        #swagger.parameters['counter'] = {
+            in: 'querystring',
+            description: 'Pagination number. Default is 0',
+            required: false,
+            type: 'number',
+            schema: { "counter": 0 }
+        }
+        #swagger.parameters['max_time'] = {
+            in: 'querystring',
+            description: 'Unix timestamp. Used to limit the maximum blockchain operation by date/time',
+            required: false,
+            type: 'number',
+            schema: { "max_time": 1618585403788 }
+        }
+        #swagger.responses[200] = {
+            schema: {
+                "result": [
+                    { $ref: "#/definitions/objkt" }
+                ]
+            }
+        }
+        #swagger.end
+    */
+
     req.body.max_time = req.query.max_time
     req.body.counter = req.query.counter
 
     return next()
   }, _asyncHandler(readFeed))
-  .post(_asyncHandler(readFeed))
+  .post(_asyncHandler(readFeed), () => {
+    /*  
+        #swagger.start
+        #swagger.path = '/feed/{featured}'
+        #swagger.method = 'post'
+        #swagger.summary = 'Main feed'
+        #swagger.description = 'Endpoint used to return the most recently minted OBJKTs. Data is returned 30 at a time, and can be paginated. Total results are limited to 2500. Use of the optional `featured` path parameter will apply a different filter to the feed.'
+        #swagger.parameters['featured'] = {
+            in: 'path',
+            type: 'string',
+            description: 'Applies a filter to the results - returning no more than 1 item per minter,
+                including only those swapped for less than 0.1 tez and that haven\'t been updated with
+                lots of hDAO.',
+            required: false,
+            schema: 'featured'
+        }
+        #swagger.parameters['counter'] = {
+            in: 'body',
+            description: 'Pagination number. Default is 0',
+            required: false,
+            type: 'number',
+            schema: { "counter": 0 }
+        }
+        #swagger.parameters['max_time'] = {
+            in: 'body',
+            description: 'Unix epoch timestamp. Used to limit the maximum blockchain operation by date/time',
+            required: false,
+            type: 'number',
+            schema: { "max_time": 1618585403788 }
+        }
+        #swagger.responses[200] = {
+            schema: {
+                "result": [
+                    { $ref: "#/definitions/objkt" }
+                ]
+            }
+        }
+        #swagger.end    */
+  })
 
 router
   .route('/random')
@@ -39,15 +118,28 @@ router
     return next()
   })
   .get((req, res, next) => {
+    /* #swagger.summary = 'Random OBJKTs'
+       #swagger.description = 'Endpoint used to return an array of a random set of OBJKTs.'
+    */
+
     req.body.counter = req.query.counter
     return next()
   }, _asyncHandler(readRandomFeed))
-  .post(_asyncHandler(readRandomFeed))
+  .post(_asyncHandler(readRandomFeed), () => {
+    /* #swagger.summary = 'Random OBJKTs'
+       #swagger.description = 'Endpoint used to return an array of a random set of OBJKTs.'
+    */
+  })
 
 router
   .route('/tz')
   .all((req, res, next) => {
     _setCacheHeaderOnSuccess(res, CACHE_MAX_AGE_MAP.issuer)
+    /* #swagger.summary = 'Account information'
+       #swagger.description = 'Endpoint used to return information about a wallet address. This
+       includes the OBJKTs that wallet created, those that it holds, and the amount of hDAO it
+       holds. Data is returned 30 at a time, and can be paginated. Total results are limited to 2500.'
+    */
 
     return next()
   })
@@ -95,6 +187,16 @@ router.get(
   },
   _asyncHandler(readRecommendCurate)
 )
+
+// Swagger docs router
+var swaggerOptions = {
+  explorer: true,
+  defaultModelsExpandDepth: -1,
+  customCssUrl: 'https://cdn.jsdelivr.net/npm/swagger-ui-themes@3.0.0/themes/3.x/theme-newspaper.css',
+  customCss: '.swagger-ui .topbar { display: none } '
+};
+router.use('/docs', swaggerUi.serve)
+router.get('/docs', swaggerUi.setup(swaggerDocument, swaggerOptions))
 
 module.exports = router
 

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const swaggerAutogen = require('swagger-autogen')()
+
+const doc = {
+  info: {
+      title: "Hic et Nunc API",
+      description: "This API is used as the backend for https://hicetnunc.xyz. It consumes information from a number of Tezos blockchain information providers, including https://cryptonomic.github.io/ConseilJS/ and https://better-call.dev/docs, along with objkt metadata sourced from IPFS"
+  },
+  host: "localhost:3001",
+  schemes: ['https','http'],
+  definitions: {
+    objkt: {
+      "objectId": "24043",
+      "ipfsHash": "QmXx8hY7nh41bFzEfXW1iiiKcEBJgsdkjvtMvP2Xj3o2Z7",
+      "minter": "tz1eT35U51k1FxduLgFFTqrcYV4b6LRtTvUr",
+      "swaps": [{ $ref: "#/definitions/swap" }],
+      "token_info": { $ref: "#/definitions/token_info"},
+      "token_id": "24043"
+    },
+    swap: {
+      "swap_id": "24043",
+      "objkt_id": "20987",
+      "amount": "14",
+      "xtz_per_objkt": "1000000"
+    },
+    token_info: {
+      "name": "Neonland II",
+      "description": "Circle",
+      "tags": [
+          "neon",
+          "circle"
+      ],
+      "symbol": "OBJKT",
+      "artifactUri": "ipfs://QmewqUfDNPf8ZV51Awwhs62nkEVHk6fBcivtEVZvpLn5Vi",
+      "displayUri": "",
+      "creators": [
+          "tz1eT35U51k1FxduLgFFTqrcYV4b6LRtTvUr"
+      ],
+      "formats": [
+          {
+              "uri": "ipfs://QmewqUfDNPf8ZV51Awwhs62nkEVHk6fBcivtEVZvpLn5Vi",
+              "mimeType": "image/png"
+          }
+      ],
+      "thumbnailUri": "ipfs://QmNrhZHUaEqxhyLfqoq1mtHSipkWHeT31LNHb1QEbDHgnc",
+      "decimals": 0,
+      "isBooleanAmount": false,
+      "shouldPreferSymbol": false
+    }
+  }
+}
+
+const outputFile = 'swagger-output.json'
+const endpointsFiles = ['lib/router/router.js']
+
+/* NOTE: if you use the express Router, you must pass in the 
+   'endpointsFiles' only the root file where the route starts,
+   such as: index.js, app.js, routes.js, ... */
+
+swaggerAutogen(outputFile, endpointsFiles, doc)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "sls offline start",
     "start-express": "NODE_ENV=development ./node_modules/.bin/nodemon index.js",
-    "pretty": "./node_modules/.bin/prettier --loglevel warn --write lib"
+    "pretty": "./node_modules/.bin/prettier --loglevel warn --write lib",
+    "swagger-autogen": "node lib/swagger.js"
   },
   "repository": {
     "type": "git",
@@ -31,7 +32,9 @@
     "loglevel": "1.7.1",
     "node-fetch": "2.6.1",
     "serverless-dotenv-plugin": "^3.8.1",
-    "serverless-http": "^2.7.0"
+    "serverless-http": "^2.7.0",
+    "swagger-autogen": "^2.7.8",
+    "swagger-ui-express": "^4.1.6"
   },
   "engines": {
     "node": "12.20.1",

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -296,14 +296,6 @@
         "parameters": [],
         "responses": {}
       }
-    },
-    "/docs": {
-      "get": {
-        "tags": [],
-        "description": "",
-        "parameters": [],
-        "responses": {}
-      }
     }
   },
   "definitions": {

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -1,0 +1,438 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Hic et Nunc API",
+    "description": "This API is used as the backend for https://hicetnunc.xyz. It consumes information from a number of Tezos blockchain information providers, including https://cryptonomic.github.io/ConseilJS/ and https://better-call.dev/docs, along with objkt metadata sourced from IPFS",
+    "version": "1.0.0"
+  },
+  "host": "localhost:3001",
+  "basePath": "/",
+  "tags": [],
+  "schemes": [
+    "https",
+    "http"
+  ],
+  "consumes": [],
+  "produces": [],
+  "paths": {
+    "/feed/{featured}": {
+      "get": {
+        "tags": [],
+        "summary": "Main feed",
+        "description": "Endpoint used to return the most recently minted OBJKTs. Data is returned 30 at a time, and can be paginated. Total results are limited to 2500. Use of the optional `featured` path parameter will apply a different filter to the feed.",
+        "parameters": [
+          {
+            "name": "featured",
+            "in": "path",
+            "required": false,
+            "type": "string",
+            "description": "Applies a filter to the results - returning no more than 1 item per minter,  including only those swapped for less than 0.1 tez and that haven't been updated with  lots of hDAO.",
+            "schema": {
+              "type": "string",
+              "example": "featured"
+            }
+          },
+          {
+            "name": "counter",
+            "in": "querystring",
+            "description": "Pagination number. Default is 0",
+            "required": false,
+            "type": "number",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "counter": {
+                  "type": "number",
+                  "example": 0
+                }
+              }
+            }
+          },
+          {
+            "name": "max_time",
+            "in": "querystring",
+            "description": "Unix timestamp. Used to limit the maximum blockchain operation by date/time",
+            "required": false,
+            "type": "number",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "max_time": {
+                  "type": "number",
+                  "example": 1618585403788
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/objkt"
+                  }
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "tags": [],
+        "summary": "Main feed",
+        "description": "Endpoint used to return the most recently minted OBJKTs. Data is returned 30 at a time, and can be paginated. Total results are limited to 2500. Use of the optional `featured` path parameter will apply a different filter to the feed.",
+        "parameters": [
+          {
+            "name": "featured",
+            "in": "path",
+            "required": false,
+            "type": "string",
+            "description": "Applies a filter to the results - returning no more than 1 item per minter,  including only those swapped for less than 0.1 tez and that haven't been updated with  lots of hDAO.",
+            "schema": {
+              "type": "string",
+              "example": "featured"
+            }
+          },
+          {
+            "name": "counter",
+            "in": "body",
+            "description": "Pagination number. Default is 0",
+            "required": false,
+            "type": "number",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "counter": {
+                  "type": "number",
+                  "example": 0
+                }
+              }
+            }
+          },
+          {
+            "name": "max_time",
+            "in": "body",
+            "description": "Unix epoch timestamp. Used to limit the maximum blockchain operation by date/time",
+            "required": false,
+            "type": "number",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "max_time": {
+                  "type": "number",
+                  "example": 1618585403788
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/objkt"
+                  }
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/random": {
+      "get": {
+        "tags": [],
+        "summary": "Random OBJKTs",
+        "description": "Endpoint used to return an array of a random set of OBJKTs.",
+        "parameters": [
+          {
+            "name": "counter",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "obj",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "counter": {
+                  "type": "string",
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "post": {
+        "tags": [],
+        "summary": "Random OBJKTs",
+        "description": "Endpoint used to return an array of a random set of OBJKTs.",
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/tz": {
+      "get": {
+        "tags": [],
+        "description": "",
+        "parameters": [
+          {
+            "name": "tz",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "obj",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "tz": {
+                  "type": "string",
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "post": {
+        "tags": [],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/objkt": {
+      "get": {
+        "tags": [],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "obj",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "objkt_id": {
+                  "type": "string",
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "post": {
+        "tags": [],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/hdao": {
+      "get": {
+        "tags": [],
+        "description": "",
+        "parameters": [
+          {
+            "name": "counter",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "obj",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "counter": {
+                  "type": "string",
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {}
+      },
+      "post": {
+        "tags": [],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/recommend_curate": {
+      "get": {
+        "tags": [],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/docs": {
+      "get": {
+        "tags": [],
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    }
+  },
+  "definitions": {
+    "objkt": {
+      "type": "object",
+      "properties": {
+        "objectId": {
+          "type": "string",
+          "example": "24043"
+        },
+        "ipfsHash": {
+          "type": "string",
+          "example": "QmXx8hY7nh41bFzEfXW1iiiKcEBJgsdkjvtMvP2Xj3o2Z7"
+        },
+        "minter": {
+          "type": "string",
+          "example": "tz1eT35U51k1FxduLgFFTqrcYV4b6LRtTvUr"
+        },
+        "swaps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/swap"
+          }
+        },
+        "token_info": {
+          "$ref": "#/definitions/token_info"
+        },
+        "token_id": {
+          "type": "string",
+          "example": "24043"
+        }
+      }
+    },
+    "swap": {
+      "type": "object",
+      "properties": {
+        "swap_id": {
+          "type": "string",
+          "example": "24043"
+        },
+        "objkt_id": {
+          "type": "string",
+          "example": "20987"
+        },
+        "amount": {
+          "type": "string",
+          "example": "14"
+        },
+        "xtz_per_objkt": {
+          "type": "string",
+          "example": "1000000"
+        }
+      }
+    },
+    "token_info": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "Neonland II"
+        },
+        "description": {
+          "type": "string",
+          "example": "Circle"
+        },
+        "tags": {
+          "type": "array",
+          "example": [
+            "neon",
+            "circle"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "symbol": {
+          "type": "string",
+          "example": "OBJKT"
+        },
+        "artifactUri": {
+          "type": "string",
+          "example": "ipfs://QmewqUfDNPf8ZV51Awwhs62nkEVHk6fBcivtEVZvpLn5Vi"
+        },
+        "displayUri": {
+          "type": "string",
+          "example": ""
+        },
+        "creators": {
+          "type": "array",
+          "example": [
+            "tz1eT35U51k1FxduLgFFTqrcYV4b6LRtTvUr"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "formats": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "uri": {
+                "type": "string",
+                "example": "ipfs://QmewqUfDNPf8ZV51Awwhs62nkEVHk6fBcivtEVZvpLn5Vi"
+              },
+              "mimeType": {
+                "type": "string",
+                "example": "image/png"
+              }
+            }
+          }
+        },
+        "thumbnailUri": {
+          "type": "string",
+          "example": "ipfs://QmNrhZHUaEqxhyLfqoq1mtHSipkWHeT31LNHb1QEbDHgnc"
+        },
+        "decimals": {
+          "type": "number",
+          "example": 0
+        },
+        "isBooleanAmount": {
+          "type": "boolean",
+          "example": false
+        },
+        "shouldPreferSymbol": {
+          "type": "boolean",
+          "example": false
+        }
+      }
+    }
+  }
+}

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -193,7 +193,8 @@
     "/tz": {
       "get": {
         "tags": [],
-        "description": "",
+        "summary": "Account information",
+        "description": "Endpoint used to return information about a wallet address. This  includes the OBJKTs that wallet created, those that it holds, and the amount of hDAO it  holds. Data is returned 30 at a time, and can be paginated. Total results are limited to 2500.",
         "parameters": [
           {
             "name": "tz",
@@ -218,7 +219,8 @@
       },
       "post": {
         "tags": [],
-        "description": "",
+        "summary": "Account information",
+        "description": "Endpoint used to return information about a wallet address. This  includes the OBJKTs that wallet created, those that it holds, and the amount of hDAO it  holds. Data is returned 30 at a time, and can be paginated. Total results are limited to 2500.",
         "parameters": [],
         "responses": {}
       }
@@ -226,7 +228,8 @@
     "/objkt": {
       "get": {
         "tags": [],
-        "description": "",
+        "summary": "OBJKT details",
+        "description": "Endpoint used to return detailed information about an OBJKT.",
         "parameters": [
           {
             "name": "id",
@@ -251,7 +254,8 @@
       },
       "post": {
         "tags": [],
-        "description": "",
+        "summary": "OBJKT details",
+        "description": "Endpoint used to return detailed information about an OBJKT.",
         "parameters": [],
         "responses": {}
       }
@@ -259,12 +263,15 @@
     "/hdao": {
       "get": {
         "tags": [],
-        "description": "",
+        "summary": "hDAO feed",
+        "description": "Endpoint used to return the list of OBJKTs with hDAO in descending  order of how many hDAO have been spend on them. Data is returned 30 at a time, and can be  paginated. Total results are limited to 30000.",
         "parameters": [
           {
             "name": "counter",
-            "in": "query",
-            "type": "string"
+            "in": "querystring",
+            "type": "number",
+            "description": "Results page count (default 0)",
+            "required": false
           },
           {
             "name": "obj",
@@ -284,14 +291,33 @@
       },
       "post": {
         "tags": [],
-        "description": "",
-        "parameters": [],
+        "summary": "hDAO feed",
+        "description": "Endpoint used to return the list of OBJKTs with hDAO in descending  order of how many hDAO have been spend on them. Data is returned 30 at a time, and can be  paginated. Total results are limited to 30000.",
+        "parameters": [
+          {
+            "name": "counter",
+            "in": "body",
+            "description": "Results page count (default 0)",
+            "type": "number",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "counter": {
+                  "type": "number",
+                  "example": 0
+                }
+              }
+            }
+          }
+        ],
         "responses": {}
       }
     },
     "/recommend_curate": {
       "get": {
         "tags": [],
+        "summary": "hDAO minimum spend recommendation",
         "description": "",
         "parameters": [],
         "responses": {}


### PR DESCRIPTION
Supercedes #41 to reflect router middleware approach

* Adds Swagger `/docs` endpoint
* Main endpoints documented with at least summary + description
* README updated with generation instructions