### PR TITLE
Featured feed: Fix issue with tzkt scores and improve rate limiting

### DIFF
--- a/lib/conseil.js
+++ b/lib/conseil.js
@@ -1114,7 +1114,7 @@ const getFeaturedArtisticUniverse = async (max_time) => {
   let minters = _.take(_.uniq(minter_arr), 30)
   const limiter = new Bottleneck({
     maxConcurrent: 1,
-    minTime: 2
+    minTime: 20
   });
   let tzktscores = new Map()
   let scoreTask = Promise.all(

--- a/lib/conseil.js
+++ b/lib/conseil.js
@@ -22,14 +22,6 @@ const ONE_HOUR_MILLIS = 60 * ONE_MINUTE_MILLIS
 const ONE_DAY_MILLIS = 24 * ONE_HOUR_MILLIS
 const ONE_WEEK_MILLIS = 7 * ONE_DAY_MILLIS
 
-Map.prototype.mapMap = function(callback) {
-  const output = new Map()
-  this.forEach((element, key)=>{
-    output.set(key, callback(element, key))
-  })
-  return output
-}
-
 Array.prototype.sum = Array.prototype.sum || function (){
   return this.reduce(function(p,c){return p+c},0);
 };
@@ -1172,11 +1164,13 @@ const getFeaturedArtisticUniverse = async (max_time) => {
   
   
   let replacementScore = Object.values(tzktscores).filter(v => v !== -1).avg() / 2
-  tzktscores = tzktscores.mapMap((value, key) => { 
+  tzktscores = _.mapValues(tzktscores, function(value) { 
     if (value === -1) {
       return replacementScore
+    } else 
+    {
+      return value
     }
-    return value
   })
   // Cost to be on feed per objekt last 7 days shouldn't be higher than any of:
   //   0.5tez


### PR DESCRIPTION
The `mapMap` function was incorrectly returning an empty map. This fix replaces the function with the `lodash` equivalent, and tzkt scores are now correctly assigned.

Before (after `tzktscores.mapMap((value, key) => {`) 

```
console.log("t2:", tzktscores)
t2: {}
```

After:
```
console.log("t2:", tzktscores)
t2: {
  tz1UAa1iDAbVdRqsSszC5dtYunps5PVXq4Nz: 1,
  tz1far2Uu2ZkyknWhjJJazdr6RNhye4GeKro: 0,
  tz1gdnqmKkbyJagbTEFc6tzbWtz6HpfgNzGd: 1,
  tz1TbG5xDWPNiNXpnJnv71Jk7gzW2Mg8QB2h: 0,
...
```

This is now producing the correct minterScore, which was defaulting to the `replacementScore` for all users.

In addition, the tzkt bottleneck was set at 2ms, which was mostly causing 429 errors. This PR increases that value to 20ms which has eliminated 429s in local testing, and still returns results in a reasonable time.
