### PR TITLE
hotfix exploit

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -100,8 +100,12 @@ async function getObjektByIdBCD(id) {
     getIpfsHash(objkt.ipfsHash),
   ])
   
+  let creators = await getRealIssuer(objkt.token_id);
+
   Object.assign(objkt, objktOwners, {
-    token_info: ipfsMetadata,
+    token_info: Object.assign({}, ipfsMetadata, {
+      creators: creators,
+    }),
     swaps: []
   })
   return objkt
@@ -123,8 +127,12 @@ async function getObjktById(id, with_swaps=true) {
       conseil.getObjkthDAOBalance(objkt.token_id).catch(() => -1)
     ])
 
+    let creators = await getRealIssuer(objkt.token_id);
+
     Object.assign(objkt, objktOwners, {
-      token_info: ipfsMetadata,
+      token_info: Object.assign({}, ipfsMetadata, {
+        creators: creators,
+      }),
       hDAO_balance: hdBalance
     })
 
@@ -134,6 +142,21 @@ async function getObjktById(id, with_swaps=true) {
     return {}
   }
 
+}
+
+async function getRealIssuer (id) {
+  try {
+    const apiUrl = `https://api.tzstats.com/explorer/bigmap/522/${id}`
+    const result = await axios.get(apiUrl)
+    if (result.data) {
+      const issuer = result.data.value.issuer
+      return [ issuer ];
+    } else {
+      throw new Error('No creator found for ' + id)
+    }
+  } catch (err) {
+    throw err;
+  }
 }
 
 async function getObjktOwners(objkt) {


### PR DESCRIPTION
- replace "creators" in `token_info` with the true issuer by fetching it directly from tzstats bigmap indexer (fetching royalties bigmap)

This is a hotfix which should hopefully fix the backend + frontend but a better fix may require using conseiljs to get the true issuer.

please test locally as I haven't been able to get full backend+frontend testing/local dev server running