### PR TITLE
fix: update serverless version to match frameworkVersion in yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Built with APIs from @Cryptonomic and @baking-bad.
 ## Running
 
 ```bash
-npm install -g serverless@2.35.0
+npm install -g serverless@2.8.0
 npm i
 npm start
 ```


### PR DESCRIPTION
Should hopefully fix #74 and #61 

I noticed that the README instructs to install `serverless@2.35.0` but the `serverless.yml` was recently pegged to `2.8.0`. Assuming the README is wrong in this case. At the very least this solves the issue of starting the server locally for me.